### PR TITLE
Remove schema store and discard the auto registration of schema

### DIFF
--- a/avro_turf.gemspec
+++ b/avro_turf.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sinatra"
   spec.add_development_dependency "json_spec"
   spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "pry", "~> 0.12.2"
 
   spec.post_install_message = %{
 avro_turf v0.8.0 deprecates the names AvroTurf::SchemaRegistry,

--- a/lib/avro_turf/in_memory_cache.rb
+++ b/lib/avro_turf/in_memory_cache.rb
@@ -5,6 +5,7 @@ class AvroTurf::InMemoryCache
   def initialize
     @schemas_by_id = {}
     @ids_by_schema = {}
+    @schemas_by_subject = {}
   end
 
   def lookup_by_id(id)
@@ -23,5 +24,13 @@ class AvroTurf::InMemoryCache
   def store_by_schema(subject, schema, id)
     key = subject + schema.to_s
     @ids_by_schema[key] = id
+  end
+
+  def lookup_by_subject(subject)
+    @schemas_by_subject[subject]
+  end
+
+  def store_by_subject(subject, schemas)
+    @schemas_by_subject[subject] = schemas
   end
 end

--- a/lib/avro_turf/messaging.rb
+++ b/lib/avro_turf/messaging.rb
@@ -82,7 +82,12 @@ class AvroTurf
     #
     # Returns the decoded message.
     def decode(data, schema_name: nil, namespace: @namespace)
-      readers_schema = schema_name && @schema_store.find(schema_name, namespace)
+      readers_schema = if schema_name
+        fullname = Avro::Name.make_fullname(schema_name, namespace)
+        schema_json = @registry.subject_version(fullname).fetch('schema')
+        Avro::Schema.parse(schema_json)
+      end
+
       stream = StringIO.new(data)
       decoder = Avro::IO::BinaryDecoder.new(stream)
 

--- a/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_confluent_schema_registry_server.rb
@@ -84,6 +84,7 @@ class FakeConfluentSchemaRegistryServer < Sinatra::Base
     {
       name: params[:subject],
       version: schema_ids.index(schema_id) + 1,
+      id: schema_id,
       schema: schema
     }.to_json
   end

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -88,16 +88,18 @@ shared_examples_for "a confluent schema registry client" do
   end
 
   describe "#subject_version" do
-    before do
-      2.times do |n|
-        registry.register(subject_name,
-                          { type: :record, name: "r#{n}", fields: [] }.to_json)
-      end
+    let!(:schema_id1) do
+      registry.register(subject_name, { type: :record, name: 'r0', fields: [] }.to_json)
     end
+    let!(:schema_id2) do
+      registry.register(subject_name, { type: :record, name: 'r1', fields: [] }.to_json)
+    end
+
     let(:expected) do
       {
         name: subject_name,
         version: 1,
+        id: schema_id1,
         schema: { type: :record, name: "r0", fields: [] }.to_json
       }.to_json
     end
@@ -112,6 +114,7 @@ shared_examples_for "a confluent schema registry client" do
         {
           name: subject_name,
           version: 2,
+          id: schema_id2,
           schema: { type: :record, name: "r1", fields: [] }.to_json
         }.to_json
       end


### PR DESCRIPTION
We don't want to manage schemas in every application, so we remove the schema store.

When encoding, we want to fetch the compatible schema from registry instead of automatically registering a new schema on registry.

To find the latest compatible schema from registry for a subject, we will cache the all schemas in memory for that subject when we initialise the AvroTurf::Messaging. The caching will be invalidated when we deploy the kafka producer (reinitialise a new AvroTurf::Messaging object).